### PR TITLE
Add CODE_OF_CONDUCT.md for GSSoC'25 contributions

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,87 @@
+**Code of Conduct — DocEase | GSSoC’25 Documentation**
+
+---
+
+***Our Commitment***
+
+DocEase is committed to fostering a respectful, inclusive, and collaborative environment for all contributors—whether you are new to open source or an experienced developer. Our goal is to ensure that every participant feels welcome, valued, and empowered to share their ideas, skills, and perspectives.
+
+---
+
+***Community Values***
+
+We strengthen our community when we:
+- Respect diverse backgrounds, skill levels, and viewpoints.
+- Encourage open, constructive discussions and healthy collaboration.
+- Communicate with professionalism, clarity, and empathy.
+- Support and mentor newcomers, acknowledging every contribution.
+- Share credit, acknowledge effort, and collaborate transparently.
+
+---
+
+***Zero Tolerance***
+
+We do not permit:
+- Harassment, discrimination, or offensive behavior in any form.
+- Unsolicited private messages or targeted negative conduct.
+- Spam, self-promotion, or irrelevant content.
+- Plagiarism or misuse of code, data, or intellectual property.
+- Any behavior that disrupts a safe and inclusive environment.
+
+---
+
+***Where This Applies***
+
+These standards apply across all DocEase platforms, including:
+- GitHub repositories (issues, pull requests, and discussions)
+- GSSoC’25 official Discord channels
+- Social media or project-related public forums
+- Online or in-person project-related events
+
+---
+
+***Reporting Violations***
+
+If you witness or experience any misconduct, please report it promptly to:
+- Project administrators or mentors (via GSSoC’25 channels)
+- DocEase maintainers (through GitHub or LinkedIn)
+- All reports will be treated confidentially and addressed in a timely manner.
+
+---
+
+***Consequences***
+
+Depending on the severity of the violation, actions may include:
+- Written warning and reminder of guidelines
+- Temporary suspension from participation
+- Permanent removal from the project or community
+
+---
+
+***Contributor Expectations***
+
+By contributing to DocEase, you agree to:
+- Maintain respectful and constructive communication in all interactions.
+- Provide proper attribution for any borrowed content or resources.
+- Keep discussions relevant to documentation and project goals.
+- Offer assistance and guidance to fellow contributors whenever possible.
+
+---
+
+***Our Vision***
+
+DocEase aims to be more than just a documentation tool—it is a space where open-source collaboration drives clarity, accessibility, and innovation. Every line written, edited, or reviewed helps create resources that benefit the broader community. Together, we strive to set a standard for professional, inclusive, and impactful open-source contribution.
+
+---
+
+***Attribution***
+
+This Code of Conduct is adapted from the [Contributor Covenant (v3.0)](https://www.contributor-covenant.org/version/3/0/code_of_conduct/), with modifications to align with the DocEase project and Girl Script Summer of Code (GSSoC’25) guidelines. 
+
+Enforcement guidelines inspired by [Mozilla’s code of conduct enforcement ladder](https://github.com/mozilla/diversity). 
+
+📌 Original work License under Creative Commons Attribution 4.0 International [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/).
+
+---
+
+**Let us work together to make DocEase a safe, collaborative, and impactful open-source project under GSSoC’25.**


### PR DESCRIPTION
📋 Description
Added a formal Code of Conduct for the DocEase project under GSSoC’25, outlining guidelines for respectful communication, inclusive collaboration, and professional open-source contributions. This document is adapted from the Contributor Covenant v3.0 with modifications specific to DocEase and GSSoC’25 requirements.

> Fixed #2 

## 🔍 Type of Change
- [ ] Bug fix 🐞
- [ ] New feature ✨
- [X] Documentation update 📝
- [ ] Refactoring or code improvement ♻️
- [ ] Other (please describe):

## 🙋 Details
- **Name**: Divya Jain
- **GitHub Username**: DivyaJain-DataAnalyst

## 🧪 How Has This Been Tested?
- Verified Markdown formatting using GitHub preview
- Confirmed all links are valid
- Reviewed content with project maintainers

## 📸 Screenshots
![1](https://github.com/user-attachments/assets/b6c0143e-dd8f-49c2-9219-295a7d28ed13)

## ✅ Checklist
- [X] I have read the contributing guidelines
- [X] I have followed the project's documentation standards
- [X] My changes are properly formatted
- [X] I have updated documentation where needed
- [X] My changes don't introduce any security concerns

## ℹ️ Additional Notes
This Code of Conduct is adapted from the Contributor Covenant (v3.0) and tailored for SSGPT's needs during GSSoC'25.